### PR TITLE
Editor Colouring Improvement [RIP-59]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import kotlin.Keys.*
+import kotlin.Keys.{kotlinRuntimeProvided, kotlinVersion, kotlincJvmTarget}
 import sbt.ThisBuild
 import org.jetbrains.sbtidea.Keys.*
 
@@ -18,7 +18,7 @@ lazy val riddlIdeaPlugin: Project = Root(
     With.build_info,
     With.coverage(90),
     With.aliases,
-    With.riddl(forJS = false, "0.52.2-13-89c9057a")
+    With.riddl("0.53.1")
   )
   .enablePlugins(KotlinPlugin, JavaAppPackaging)
   .settings(
@@ -28,9 +28,12 @@ lazy val riddlIdeaPlugin: Project = Root(
     buildInfoPackage := "com.ossuminc.riddl.plugins.idea",
     buildInfoObject := "RiddlIDEAPluginBuildInfo",
     description := "The plugin for supporting RIDDL in IntelliJ",
-    libraryDependencies ++= Dep.testing ++ Dep.basic :+ Dep.kotlin,
+    libraryDependencies ++= Dep.testing ++ Dep.basic ++ Seq(
+      Dep.kotlin,
+      Dep.riddlCommands
+    ),
     Test / parallelExecution := false,
-    scalaVersion := "3.4.0",
+    scalaVersion := "3.4.3",
     ThisBuild / intellijPluginName := "RIDDL4IDEA",
     ThisBuild / intellijBuild := "242.23339.11",
     ThisBuild / intellijPlatform := IntelliJPlatform.IdeaUltimate,
@@ -41,5 +44,5 @@ lazy val riddlIdeaPlugin: Project = Root(
     Compile / unmanagedResourceDirectories += baseDirectory.value / "resources",
     Test / unmanagedResourceDirectories += baseDirectory.value / "testResources",
     runIDE / javaOptions += "-Didea.http.proxy.port=5432,-DurlSchemes=http://localhost",
-    unmanagedBase := baseDirectory.value / "lib",
+    unmanagedBase := baseDirectory.value / "lib"
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dep {
     "com.eclipsesource.minimal-json" % "minimal-json" % "0.9.5" withSources ()
   }
   val kotlin = "org.jetbrains.kotlin" % "kotlin-stdlib" % "2.0.20"
+  val riddlCommands = "com.ossuminc" % "riddl-commands_3" % "0.53.1"
 
   val basic: Seq[ModuleID] = Seq(minimalJson, scalactic, scalatest, scalacheck)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.15.0")
+addSbtPlugin("com.ossuminc" % "sbt-ossuminc" % "0.16.2")
 addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.26.2")
 addSbtPlugin("org.jetbrains.scala" % "sbt-kotlin-plugin" % "3.0.3")
 


### PR DESCRIPTION
This was mostly an attempt to ensure that some bugs with editor colouring - in particular, modifications of keywords by deleting or typing for the first time - and RIDDL + sbt-ossuminc were upgraded in the process

At present, deleting a letter of a coloured word is still buggy - the rest of the word may go white, and when the letter is  retyped only that one letter may be coloured, until either the letter is deleted & added again or the line is cut-pasted - but the indexes being used by the colouring function (`files/utils/applyColourToKey -> editor.getMarkupModel.addRangeHighlighter`) are targeting the correct characters.