### PR TITLE
Links from errors in console [RIP-40]

### DIFF
--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/actions/RiddlToolWindowCompileAction.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/actions/RiddlToolWindowCompileAction.scala
@@ -11,9 +11,7 @@ import com.ossuminc.riddl.plugins.idea.utils.ToolWindowUtils.updateToolWindowPan
 import com.ossuminc.riddl.plugins.idea.utils.ManagerBasedGetterUtils.getRiddlIdeaState
 import org.jetbrains.annotations.NotNull
 
-class RiddlToolWindowCompileAction extends AnAction with DumbAware {
-  private var windowNum: Int = -1
-  def setWindowNum(num: Int): Unit = windowNum = num
+class RiddlToolWindowCompileAction(windowNum: Int) extends AnAction with DumbAware {
 
   override def actionPerformed(@NotNull anActionEvent: AnActionEvent): Unit = {
     getRiddlIdeaState(windowNum).clearRunOutput()

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/actions/RiddlToolWindowSettingsOpenAction.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/actions/RiddlToolWindowSettingsOpenAction.scala
@@ -10,10 +10,9 @@ import com.intellij.openapi.project.DumbAware
 import com.ossuminc.riddl.plugins.idea.utils.ToolWindowUtils.openToolWindowSettings
 import org.jetbrains.annotations.NotNull
 
-class RiddlToolWindowSettingsOpenAction extends AnAction with DumbAware {
-  private var windowNum: Int = 1
-  def setWindowNum(num: Int): Unit = windowNum = num
-
+class RiddlToolWindowSettingsOpenAction(windowNum: Int)
+    extends AnAction
+    with DumbAware {
   override def actionPerformed(@NotNull anActionEvent: AnActionEvent): Unit =
     openToolWindowSettings(windowNum)
 

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/files/utils.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/files/utils.scala
@@ -60,14 +60,14 @@ object utils {
         .zip(splitText)
         .filter(_._2.trim.nonEmpty)
         .map(getSubStringsWithIndices)
-    else {
+    else if !doc.isBlank then {
       Seq(
         getSubStringsWithIndices(
-          if doc.charAt(start - 1).isWhitespace then 0 else -1,
+          if doc.charAt(start).isWhitespace then 0 else -1,
           ""
         )
       )
-    }
+    } else Seq()
   }
 
   def highlightKeywords(text: String, editor: Editor): Unit = {

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/settings/RiddlIdeaSettingsComponent.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/settings/RiddlIdeaSettingsComponent.scala
@@ -68,7 +68,6 @@ class RiddlIdeaSettingsComponent(private val numToolWindow: Int) {
 
     confFileTextField
   }
-
   private def createParamButton(
       commonOption: CommonOption
   ): JBPanel[?] = {
@@ -155,6 +154,7 @@ class RiddlIdeaSettingsComponent(private val numToolWindow: Int) {
     CommonOptionsUtils.AllCommonOptions.foreach(option =>
       commonOptionsPanel.add(createParamButton(option))
     )
+    println(state.getCommonOptions.noANSIMessages)
 
     riddlFormBuilder
       .addLabeledComponent(

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/settings/RiddlIdeaSettingsComponent.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/settings/RiddlIdeaSettingsComponent.scala
@@ -154,7 +154,6 @@ class RiddlIdeaSettingsComponent(private val numToolWindow: Int) {
     CommonOptionsUtils.AllCommonOptions.foreach(option =>
       commonOptionsPanel.add(createParamButton(option))
     )
-    println(state.getCommonOptions.noANSIMessages)
 
     riddlFormBuilder
       .addLabeledComponent(

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/ui/RiddlTerminalConsole.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/ui/RiddlTerminalConsole.scala
@@ -1,14 +1,12 @@
 package com.ossuminc.riddl.plugins.idea.ui
 
-import com.intellij.execution.filters.{HyperlinkInfo, HyperlinkInfoBase}
+import com.intellij.execution.filters.HyperlinkInfoBase
 import com.intellij.execution.impl.ConsoleViewImpl
-import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.editor.{Editor, LogicalPosition}
 import com.intellij.openapi.fileEditor.{FileEditorManager, OpenFileDescriptor}
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.{LocalFileSystem, VirtualFile}
-import com.intellij.terminal.TerminalExecutionConsole
 import com.intellij.ui.awt.RelativePoint
 
 import scala.util.matching.Regex

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/ui/RiddlTerminalConsole.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/ui/RiddlTerminalConsole.scala
@@ -1,0 +1,89 @@
+package com.ossuminc.riddl.plugins.idea.ui
+
+import com.intellij.execution.filters.{HyperlinkInfo, HyperlinkInfoBase}
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.editor.{Editor, LogicalPosition}
+import com.intellij.openapi.fileEditor.{FileEditorManager, OpenFileDescriptor}
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.{LocalFileSystem, VirtualFile}
+import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.ui.awt.RelativePoint
+
+import scala.util.matching.Regex
+
+class RiddlTerminalConsole(
+    numWindow: Int,
+    project: Project
+) extends ConsoleViewImpl(project, true) {
+  override def print(
+      text: String,
+      contentType: ConsoleViewContentType
+  ): Unit = {
+    val linePattern = """\[\w+\] ([\w/_-]+\.riddl)\((\d+):(\d+)\)\:""".r
+    text
+      .split("\n")
+      .toList
+      .foreach { line =>
+        linePattern.findFirstMatchIn(line) match
+          case Some(resultMatch: Regex.Match) =>
+            linkToEditor(
+              line,
+              resultMatch.group(1),
+              resultMatch.group(2).toInt,
+              resultMatch.group(3).toInt
+            )
+          case None =>
+            super.print(line + "\n", ConsoleViewContentType.NORMAL_OUTPUT)
+      }
+    ()
+  }
+
+  private def linkToEditor(
+      textLine: String,
+      fileName: String,
+      lineNumber: Int,
+      charNumber: Int
+  ): Unit = {
+    import com.ossuminc.riddl.plugins.idea.utils.ManagerBasedGetterUtils.getRiddlIdeaState
+
+    val pathToConf = getRiddlIdeaState(numWindow).getConfPath
+      .split("/")
+      .dropRight(1)
+      .mkString("/")
+
+    val file: VirtualFile =
+      LocalFileSystem.getInstance.findFileByPath(
+        s"$pathToConf/$fileName"
+      )
+
+    val hyperlinkInfo = new HyperlinkInfoBase {
+      override def navigate(
+          project: Project,
+          relativePoint: RelativePoint
+      ): Unit = {
+        val editor: Editor = FileEditorManager
+          .getInstance(project)
+          .openTextEditor(
+            new OpenFileDescriptor(
+              project,
+              file,
+              lineNumber - 1,
+              charNumber - 1
+            ),
+            true
+          )
+        if editor != null then {
+          val logicalPosition =
+            new LogicalPosition(
+              lineNumber - 1,
+              charNumber - 1
+            )
+          editor.getCaretModel.moveToLogicalPosition(logicalPosition)
+        }
+      }
+    }
+    this.printHyperlink(textLine + "\n", hyperlinkInfo)
+  }
+}

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/ui/RiddlToolWindowFactory.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/ui/RiddlToolWindowFactory.scala
@@ -51,12 +51,10 @@ class RiddlToolWindowContent(
     )
   actionGroup.add(new RiddlNewToolWindowAction)
   private val compileAction: RiddlToolWindowCompileAction =
-    new RiddlToolWindowCompileAction()
-  compileAction.setWindowNum(numWindow)
+    new RiddlToolWindowCompileAction(numWindow)
   actionGroup.add(compileAction)
   private val openAction: RiddlToolWindowSettingsOpenAction =
-    new RiddlToolWindowSettingsOpenAction
-  openAction.setWindowNum(numWindow)
+    new RiddlToolWindowSettingsOpenAction(numWindow)
   actionGroup.add(openAction)
 
   private val actionToolbar: ActionToolbar = ActionManager

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/utils/ParsingUtils.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/utils/ParsingUtils.scala
@@ -1,7 +1,6 @@
 package com.ossuminc.riddl.plugins.idea.utils
 
 import com.ossuminc.riddl.commands.Commands
-import com.ossuminc.riddl.language.CommonOptions
 import com.ossuminc.riddl.passes.PassesResult
 import com.ossuminc.riddl.plugins.idea.settings.RiddlIdeaSettings
 import com.ossuminc.riddl.utils.{Logger, Logging}
@@ -29,7 +28,6 @@ object ParsingUtils {
   ): Unit = {
     val windowState: RiddlIdeaSettings.State = getRiddlIdeaState(numWindow)
 
-    println(getRiddlIdeaState(numWindow).getCommonOptions)
     Commands.runCommandWithArgs(
       Array(
         windowState.getCommand,


### PR DESCRIPTION
- Links tested to work
- `TerminalExecutionConsole` replaced with `ConsoleViewImpl`
<img width="741" alt="Screenshot 2024-10-18 at 1 01 46 PM" src="https://github.com/user-attachments/assets/56896872-53fb-4643-9f00-059c55f80762">
(ANSI codes present due to RIDDL bug)
