### PR TITLE
errors with messages in editor [RIP-41]

### DIFF
--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlDocumentListener.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlDocumentListener.scala
@@ -5,7 +5,7 @@ import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.util.TextRange
 import com.ossuminc.riddl.plugins.idea.files.utils.{
   getWholeWordsSubstrings,
-  highlightKeywordsInDoc
+  highlightKeywordsOnChange
 }
 import com.ossuminc.riddl.plugins.idea.files.RiddlTokenizer.*
 
@@ -22,7 +22,7 @@ class RiddlDocumentListener extends DocumentListener {
         newText,
         event.getOffset
       )
-      highlightKeywordsInDoc(
+      highlightKeywordsOnChange(
         wholeWords
           .zip(
             RiddlTokenizer

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlFileListenerHighlighter.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlFileListenerHighlighter.scala
@@ -3,22 +3,45 @@ package com.ossuminc.riddl.plugins.idea.files
 import com.intellij.openapi.fileEditor.{
   FileDocumentManager,
   FileEditorManager,
+  FileEditorManagerEvent,
   FileEditorManagerListener,
   TextEditor
 }
 import com.intellij.openapi.vfs.VirtualFile
+import com.ossuminc.riddl.plugins.idea.utils.ManagerBasedGetterUtils.{
+  getProject,
+  getRiddlIdeaStates
+}
+import com.ossuminc.riddl.plugins.idea.utils.highlightErrorForFile
 
 class RiddlFileListenerHighlighter extends FileEditorManagerListener {
   override def fileOpened(
       source: FileEditorManager,
       file: VirtualFile
-  ): Unit = source.getAllEditors(file).foreach { te =>
-    val doc = FileDocumentManager.getInstance().getDocument(file)
-    if doc != null then {
-      te match {
-        case textEditor: TextEditor =>
-          utils.highlightKeywords(doc.getText, textEditor.getEditor)
+  ): Unit = highlightKeywordsAndErrors(source, file)
+
+  override def selectionChanged(event: FileEditorManagerEvent): Unit =
+    if event.getNewFile != null then
+      highlightKeywordsAndErrors(
+        FileEditorManager
+          .getInstance(getProject),
+        event.getNewFile
+      )
+
+  private def highlightKeywordsAndErrors(
+      source: FileEditorManager,
+      file: VirtualFile
+  ): Unit = source
+    .getAllEditors(file)
+    .foreach { te =>
+      val doc = FileDocumentManager.getInstance().getDocument(file)
+      if doc != null then {
+        te match {
+          case textEditor: TextEditor =>
+            utils.highlightKeywords(doc.getText, textEditor.getEditor)
+            getRiddlIdeaStates.allStates
+              .foreach((_, state) => highlightErrorForFile(state, file.getName))
+        }
       }
     }
-  }
 }

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlFileType.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlFileType.scala
@@ -1,8 +1,7 @@
 package com.ossuminc.riddl.plugins.idea.files
 
 import com.intellij.lang.Language
-import com.intellij.openapi.fileTypes.{LanguageFileType, PlainTextLanguage}
-import com.intellij.openapi.util.IconLoader
+import com.intellij.openapi.fileTypes.LanguageFileType
 import com.ossuminc.riddl.plugins.idea.utils.RiddlIcon
 
 import javax.swing.Icon

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlTokenizer.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/files/RiddlTokenizer.scala
@@ -1,9 +1,7 @@
 package com.ossuminc.riddl.plugins.idea.files
 
 import com.intellij.ide.highlighter.custom.CustomHighlighterColors
-import com.intellij.openapi.editor.{DefaultLanguageHighlighterColors, Document}
 import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.intellij.psi.CustomHighlighterTokenType
 import com.ossuminc.riddl.plugins.idea.files.utils.splitByBlanks
 
 object RiddlTokenizer {

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/files/utils.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/files/utils.scala
@@ -75,9 +75,11 @@ object utils {
     RiddlTokenizer.tokenize(text).filter(!_._1.isBlank).foreach {
       applyColorToToken(editor)
     }
+
   }
 
-  def highlightKeywordsInDoc(
+  def highlightKeywordsOnChange(
+      // see applyColorToToken for names of elements in tokens
       tokens: Seq[(String, Int, Seq[Boolean])],
       editor: Editor
   ): Unit = tokens.foreach(applyColorToToken(editor))

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/settings/RiddlIdeaSettings.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/settings/RiddlIdeaSettings.scala
@@ -30,7 +30,8 @@ object RiddlIdeaSettings {
     def load(newStates: States): Unit = states = newStates.states
 
     def getState(numToolWindow: Int): State = states(numToolWindow)
-
+    def allStates: Map[Int, State] = states
+    
     def length: Int = states.size
 
     def newState(): Int = {
@@ -39,7 +40,7 @@ object RiddlIdeaSettings {
           .find(num => !states.keys.iterator.toSeq.contains(num))
           .getOrElse(length + 1)
 
-      states = states.concat(Map(newWindowNum -> new State))
+      states = states.concat(Map(newWindowNum -> new State(newWindowNum)))
       newWindowNum
     }
 
@@ -47,13 +48,15 @@ object RiddlIdeaSettings {
       states = states.view.filterKeys(_ != numWindow).toMap
   }
 
-  class State {
+  class State(windowNum: Int) {
     private var riddlConfPath: String = ""
     private var riddlRunOutput: Seq[String] = Seq()
     private var autoCompileOnSave: Boolean = true
     private var command: String = commands.head
     private var commonOptions: CommonOptions = CommonOptions.empty.copy(noANSIMessages = true, groupMessagesByKind = true)
 
+    def getWindowNum: Int = windowNum
+    
     def setConfPath(newPath: String): Unit = riddlConfPath = newPath
     def getConfPath: String = riddlConfPath
 

--- a/src/main/scala/com/ossuminc/riddl/plugins/idea/utils/ToolWindowUtils.scala
+++ b/src/main/scala/com/ossuminc/riddl/plugins/idea/utils/ToolWindowUtils.scala
@@ -20,13 +20,12 @@ import com.ossuminc.riddl.plugins.idea.ui.{
 }
 import ParsingUtils.*
 import CreationUtils.*
-import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.ui.components.JBPanel
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.execution.ui.ConsoleViewContentType
-import com.intellij.execution.process.OSProcessHandler
+import com.intellij.openapi.fileEditor.FileEditorManager
 
 import scala.jdk.CollectionConverters.*
 import java.awt.GridBagConstraints
@@ -179,6 +178,12 @@ object ToolWindowUtils {
             s"This window's configuration file:\n  " + statePath + "\nwas not found, please configure it in settings"
           )
       else if fromReload then runCommandForWindow(numWindow)
+
+      val fileEditorManager = FileEditorManager
+        .getInstance(project)
+
+      fileEditorManager.getSelectedFiles
+        .foreach(file => highlightErrorForFile(state, file.getName))
     }
 
     // enables auto-compiling


### PR DESCRIPTION
The error highlighting seen in the screenshot below has been ensured & tested to:
- be generated for whichever file is open during running the `from` command
- be generated when a file with an error is opened
  - from a link in the RIDDL run window
  - manually by a user

<img width="868" alt="Screenshot 2024-10-23 at 11 46 11 AM" src="https://github.com/user-attachments/assets/8e1a9c74-4a2f-4ad9-834b-93fc951be519">
